### PR TITLE
PyPI publish CI: Use latest release of gh-action-pypi-publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: acheong08
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Update the [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) action to the stable release branch, which contains the latest release, as recommended by [their docs](https://github.com/pypa/gh-action-pypi-publish/tree/unstable/v1#usage).