### PR TITLE
Chatbot -> ChatBot

### DIFF
--- a/src/revChatGPT/revChatGPT.py
+++ b/src/revChatGPT/revChatGPT.py
@@ -15,7 +15,7 @@ def generate_uuid() -> str:
     return uid
 
 
-class Chatbot:
+class ChatBot:
     config: json
     conversation_id: str
     parent_id: str


### PR DESCRIPTION
Either this or fix the docs, the docs specify `from revChatGPT.revChatGPT import ChatBot`, but it's currently called `Chatbot` (lowercase B)

havent tested this