### PR TITLE
Define a constant for the base URL of the API

### DIFF
--- a/src/revChatGPT/revChatGPT.py
+++ b/src/revChatGPT/revChatGPT.py
@@ -8,6 +8,8 @@ import requests
 
 from OpenAIAuth.OpenAIAuth import OpenAIAuth, Debugger
 
+BASE_URL = "https://chat.openai.com/"
+
 
 def generate_uuid() -> str:
     uid = str(uuid.uuid4())
@@ -62,7 +64,7 @@ class Chatbot:
     # Generator for chat stream -- Internal use only
     def get_chat_stream(self, data) -> None:
         response = requests.post(
-            "https://chat.openai.com/backend-api/conversation",
+            BASE_URL+"backend-api/conversation",
             headers=self.headers,
             data=json.dumps(data),
             stream=True,
@@ -112,7 +114,7 @@ class Chatbot:
                 "https": self.config["proxy"],
             }
         response = s.post(
-            "https://chat.openai.com/backend-api/conversation",
+            BASE_URL+"backend-api/conversation",
             data=json.dumps(data),
         )
         try:
@@ -200,7 +202,7 @@ class Chatbot:
             )
             # s.cookies.set("__Secure-next-auth.csrf-token", self.config['csrf_token'])
             response = s.get(
-                "https://chat.openai.com/api/auth/session",
+                BASE_URL+"api/auth/session",
                 headers={
                     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, "
                     "like Gecko) Version/16.1 Safari/605.1.15 ",


### PR DESCRIPTION
Defined a constant variable "BASE_URL" set to "https://chat.openai.com/"

Makes it easier to change the URL if necessary and improves readability. Did not define a variable for API endpoints as there are only 2. 
As requested in #141 