### PR TITLE
Support XDG Base Directory specification for config.json

### DIFF
--- a/wiki/Setup.md
+++ b/wiki/Setup.md
@@ -2,7 +2,7 @@
 ## Install
 `pip3 install revChatGPT --upgrade`
 
-Make the necessary changes in `config.json.example` and save as `config.json`
+Make the necessary changes in `config.json.example` and save as `config.json` in the current working directory, in `$XDG_CONFIG_HOME/revChatGPT/config.json`, or in `$HOME/revChatGPT/config.json`.
 
 <details>
 <summary>
@@ -16,14 +16,14 @@ Make the necessary changes in `config.json.example` and save as `config.json`
     "password": "<YOUR_PASSWORD>"
 }
 ```
-Save this in `config.json` in current working directory
+Save this in `config.json` in current working directory, in `$XDG_CONFIG_HOME/revChatGPT/config.json`, or in `$HOME/revChatGPT/config.json`.
 
 </details>
 
 <details>
 <summary>
 
-## Session Token Authentication 
+## Session Token Authentication
 Use if using third-party providers (Google / Microsoft Auth) or if email/password rate limited
 </summary>
 
@@ -34,7 +34,7 @@ Go to https://chat.openai.com/chat and log in or sign up
 ![image](https://user-images.githubusercontent.com/36258159/205494773-32ef651a-994d-435a-9f76-a26699935dac.png)
 3. Copy the value for `__Secure-next-auth.session-token` and paste it into `config.json.example` under `session_token`. You do not need to fill out `Authorization`
 ![image](https://user-images.githubusercontent.com/36258159/205495076-664a8113-eda5-4d1e-84d3-6fad3614cfd8.png)
-4. Save the modified file to `config.json` (In the current working directory)
+4. Save the modified file as `config.json` in the current working directory, as `$XDG_CONFIG_HOME/revChatGPT/config.json`, or as `$HOME/revChatGPT/config.json`.
 
 ```json
 {
@@ -53,7 +53,7 @@ Use this only if all else fails. Refreshing the session does not work here. You 
 </summary>
 
 1. Log in to https://chat.openai.com/
-2. Go to https://chat.openai.com/api/auth/session 
+2. Go to https://chat.openai.com/api/auth/session
 3. Copy the `accessToken`
 4. Replace the <accessToken> with the accessToken value using the below format
 ```json
@@ -61,6 +61,6 @@ Use this only if all else fails. Refreshing the session does not work here. You 
 	"Authorization":"<accessToken>"
 }
 ```
-5. Save to `config.json`
+5. Save as `config.json` in the current working directory, as `$XDG_CONFIG_HOME/revChatGPT/config.json`, or as `$HOME/revChatGPT/config.json`.
 
 </details>


### PR DESCRIPTION
The [XDG Base Directory specification](https://wiki.archlinux.org/title/XDG_Base_Directory) specifies the environment variable `XDG_CONFIG_HOME` to hold the directory for user-specific configurations. Furthermore, configuration files are commonly placed under the `~/.config` directory. Hence, this PR adds support for configuration in these locations.

With this PR, the following paths are checked for configuration, in order of predence (highest to lowest) -- the first found file is used:
* `config.json` in the current directory (as before)
* `$XDG_CONFIG_HOME/revChatGPT/config.json`, if the environment variable `XDG_CONFIG_HOME` is set
* `$HOME/.config/revChatGPT/config.json`, if the environment variable `HOME` is set (in most cases it is).