### PR TITLE
Refactor the code and fix wiki

### DIFF
--- a/src/asyncChatGPT/asyncChatGPT.py
+++ b/src/asyncChatGPT/asyncChatGPT.py
@@ -11,9 +11,10 @@ from OpenAIAuth.OpenAIAuth import OpenAIAuth, Debugger
 
 def generate_uuid() -> str:
     """
-    Generates a UUID for the session -- Internal use only
+    Generate a UUID for the session -- Internal use only
 
-    :return: str
+    :return: a random UUID
+    :rtype: :obj:`str`
     """
     uid = str(uuid.uuid4())
     return uid
@@ -21,7 +22,7 @@ def generate_uuid() -> str:
 
 class Chatbot:
     """
-    Initializes the chatbot
+    Initialize the chatbot.
 
     See wiki for the configuration json:
     https://github.com/acheong08/ChatGPT/wiki/Setup
@@ -44,7 +45,8 @@ class Chatbot:
     :param request_timeout: The network request timeout seconds
     :type request_timeout: :obj:`int`, optional
 
-    :return: None or Exception
+    :return: The Chatbot object
+    :rtype: :obj:`Chatbot`
     """
     config: json
     conversation_id: str
@@ -72,7 +74,7 @@ class Chatbot:
 
     def reset_chat(self) -> None:
         """
-        Resets the conversation ID and parent ID
+        Reset the conversation ID and parent ID.
 
         :return: None
         """
@@ -81,7 +83,7 @@ class Chatbot:
 
     def refresh_headers(self) -> None:
         """
-        Refreshes the headers -- Internal use only
+        Refresh the headers -- Internal use only
 
         :return: None
         """
@@ -102,9 +104,10 @@ class Chatbot:
 
     async def __get_chat_stream(self, data) -> None:
         """
-        Generator for chat stream -- Internal use only
+        Generator for the chat stream -- Internal use only
 
         :param data: The data to send
+        :type data: :obj:`dict`
 
         :return: None
         """
@@ -115,7 +118,7 @@ class Chatbot:
             headers=self.headers,
             data=json.dumps(data),
             timeout=self.request_timeout,
-        )as response:
+        ) as response:
             async for line in response.aiter_lines():
                 try:
                     line = line[:-1]
@@ -141,11 +144,13 @@ class Chatbot:
 
     async def __get_chat_text(self, data) -> dict:
         """
-        Gets the chat response as text -- Internal use only
+        Get the chat response as text -- Internal use only
 
         :param data: The data to send
+        :type data: :obj:`dict`
 
         :return: The chat response
+        :rtype: :obj:`dict`
         """
         # Create request session
         s = httpx.Client(http2=True)
@@ -197,9 +202,9 @@ class Chatbot:
                 "parent_id": self.parent_id,
             }
 
-    async def get_chat_response(self, prompt, output="text") -> dict or None:
+    async def get_chat_response(self, prompt: str, output="text") -> dict or None:
         """
-        Gets the chat response
+        Get the chat response.
 
         :param prompt: The message sent to the chatbot
         :type prompt: :obj:`str`
@@ -207,8 +212,8 @@ class Chatbot:
         :param output: The output type `text` or `stream`
         :type output: :obj:`str`, optional
 
-        :return: The chat response `{"message": "Returned messages", "conversation_id": "conversation ID", "parent_id": "parent ID"}`
-        :rtype: :obj:`dict` or :obj:`None` or :obj:`Exception`
+        :return: The chat response `{"message": "Returned messages", "conversation_id": "conversation ID", "parent_id": "parent ID"}` or None
+        :rtype: :obj:`dict` or :obj:`None`
         """
         data = {
             "action": "next",
@@ -234,18 +239,18 @@ class Chatbot:
 
     def rollback_conversation(self) -> None:
         """
-        Rollbacks the conversation
+        Rollback the conversation.
 
         :return: None
         """
         self.conversation_id = self.conversation_id_prev
         self.parent_id = self.parent_id_prev
 
-    def refresh_session(self) -> Exception or None:
+    def refresh_session(self) -> None:
         """
-        Refreshes the session
+        Refresh the session.
 
-        :return: None or Exception
+        :return: None
         """
         # Either session_token, email and password or Authorization is required
         if self.config.get("session_token"):
@@ -329,7 +334,7 @@ class Chatbot:
 
     def login(self, email: str, password: str) -> None:
         """
-        Logs in to OpenAI
+        Log in to OpenAI.
 
         :param email: The email
         :type email: :obj:`str`

--- a/src/asyncChatGPT/asyncChatGPT.py
+++ b/src/asyncChatGPT/asyncChatGPT.py
@@ -67,10 +67,22 @@ class Chatbot:
         self.base_url = "https://chat.openai.com/"
         self.request_timeout = request_timeout
         self.captcha_solver = captcha_solver
+        self.headers = {
+            "Host": "chat.openai.com",
+            "Accept": "text/event-stream",
+            "Authorization": "Bearer ",
+            "Content-Type": "application/json",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) "
+            "Version/16.1 Safari/605.1.15",
+            "X-Openai-Assistant-App-Id": "",
+            "Connection": "close",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": "https://chat.openai.com/chat",
+        }
         if ("session_token" in config or ("email" in config and "password" in config)) and refresh:
             self.refresh_session()
         if "Authorization" in config:
-            self.refresh_headers()
+            self.__refresh_headers()
 
     def reset_chat(self) -> None:
         """
@@ -81,7 +93,7 @@ class Chatbot:
         self.conversation_id = None
         self.parent_id = generate_uuid()
 
-    def refresh_headers(self) -> None:
+    def __refresh_headers(self) -> None:
         """
         Refresh the headers -- Internal use only
 
@@ -89,18 +101,7 @@ class Chatbot:
         """
         if not self.config.get("Authorization"):
             self.config["Authorization"] = ""
-        self.headers = {
-            "Host": "chat.openai.com",
-            "Accept": "text/event-stream",
-            "Authorization": "Bearer " + self.config["Authorization"],
-            "Content-Type": "application/json",
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) "
-            "Version/16.1 Safari/605.1.15",
-            "X-Openai-Assistant-App-Id": "",
-            "Connection": "close",
-            "Accept-Language": "en-US,en;q=0.9",
-            "Referer": "https://chat.openai.com/chat",
-        }
+        self.headers["Authorization"] = "Bearer " + self.config["Authorization"]
 
     async def __get_chat_stream(self, data) -> None:
         """
@@ -273,10 +274,40 @@ class Chatbot:
                     "like Gecko) Version/16.1 Safari/605.1.15 ",
                 },
             )
+            # Check the response code
+            if response.status_code != 200:
+                self.debugger.log(
+                    f"Invalid status code: {response.status_code}")
+                raise Exception("Wrong response code")
+            # Try to get new session token and Authorization
+            try:
+                if 'error' in response.json():
+                    self.debugger.log("Error in response JSON")
+                    self.debugger.log(response.json()['error'])
+                    raise Exception
+                self.config["session_token"] = response.cookies.get(
+                    "__Secure-next-auth.session-token",
+                )
+                self.config["Authorization"] = response.json()["accessToken"]
+                self.__refresh_headers()
+            # If it fails, try to login with email and password to get tokens
+            except Exception:
             # Check if response JSON is empty
-            if response.json() == {}:
-                self.debugger.log("Empty response")
-                self.debugger.log("Probably invalid session token")
+                if response.json() == {}:
+                    self.debugger.log("Empty response")
+                    self.debugger.log("Probably invalid session token")
+                # Check if ['detail']['code'] == 'token_expired' in response JSON
+                # First check if detail is in response JSON
+                elif 'detail' in response.json():
+                    # Check if code is in response JSON
+                    if 'code' in response.json()['detail']:
+                        # Check if code is token_expired
+                        if response.json()['detail']['code'] == 'token_expired':
+                            self.debugger.log("Token expired")
+                else:
+                    self.debugger.log(f"Response: '{response.text}'")
+                self.debugger.log("Cannot refresh the session, try to login")
+                # Try to login
                 if 'email' in self.config and 'password' in self.config:
                     del self.config['session_token']
                     self.login(self.config['email'],
@@ -285,39 +316,7 @@ class Chatbot:
                     self.debugger.log(
                         "Invalid token and no email and password provided")
                     raise ValueError(
-                        "No email and password provided")
-            # Check if ['detail']['code'] == 'token_expired' in response JSON
-            # First check if detail is in response JSON
-            if 'detail' in response.json():
-                # Check if code is in response JSON
-                if 'code' in response.json()['detail']:
-                    # Check if code is token_expired
-                    if response.json()['detail']['code'] == 'token_expired':
-                        self.debugger.log("Token expired")
-                        if 'email' in self.config and 'password' in self.config:
-                            del self.config['session_token']
-                            self.login(self.config['email'],
-                                       self.config['password'])
-                        else:
-                            self.debugger.log(
-                                "Invalid token and no email and password provided")
-                            raise ValueError(
-                                "No email and password provided")
-            if response.status_code != 200:
-                self.debugger.log(
-                    f"Invalid status code: {response.status_code}")
-                raise Exception("Wrong response code")
-            try:
-                self.config["session_token"] = response.cookies.get(
-                    "__Secure-next-auth.session-token",
-                )
-                self.config["Authorization"] = response.json()["accessToken"]
-                self.refresh_headers()
-            except Exception as exc:
-                print("Error refreshing session")
-                self.debugger.log("Response: '" + str(response.text) + "'")
-                self.debugger.log(str(response.status_code))
-                raise Exception("Error refreshing session") from exc
+                        "Error refreshing session: No email and password provided")
         elif "email" in self.config and "password" in self.config:
             try:
                 self.login(self.config["email"], self.config["password"])
@@ -325,7 +324,7 @@ class Chatbot:
                 self.debugger.log("Login failed")
                 raise exc
         elif "Authorization" in self.config:
-            self.refresh_headers()
+            self.__refresh_headers()
         else:
             self.debugger.log(
                 "No session_token, email and password or Authorization provided")
@@ -370,6 +369,6 @@ class Chatbot:
                         self.config["session_token"] = possible_tokens[0]
                     else:
                         self.config["session_token"] = possible_tokens
-            self.refresh_headers()
+            self.__refresh_headers()
         else:
             raise Exception("Error logging in")

--- a/src/revChatGPT/revChatGPT.py
+++ b/src/revChatGPT/revChatGPT.py
@@ -11,9 +11,10 @@ from OpenAIAuth.OpenAIAuth import OpenAIAuth, Debugger
 
 def generate_uuid() -> str:
     """
-    Generates a UUID for the session -- Internal use only
+    Generate a UUID for the session -- Internal use only
 
-    :return: str
+    :return: a random UUID
+    :rtype: :obj:`str`
     """
     uid = str(uuid.uuid4())
     return uid
@@ -21,7 +22,7 @@ def generate_uuid() -> str:
 
 class Chatbot:
     """
-    Initializes the chatbot
+    Initialize the chatbot.
 
     See wiki for the configuration json:
     https://github.com/acheong08/ChatGPT/wiki/Setup
@@ -44,7 +45,8 @@ class Chatbot:
     :param request_timeout: The network request timeout seconds
     :type request_timeout: :obj:`int`, optional
 
-    :return: None or Exception
+    :return: The Chatbot object
+    :rtype: :obj:`Chatbot`
     """
     config: json
     conversation_id: str
@@ -72,7 +74,7 @@ class Chatbot:
 
     def reset_chat(self) -> None:
         """
-        Resets the conversation ID and parent ID
+        Reset the conversation ID and parent ID.
 
         :return: None
         """
@@ -81,7 +83,7 @@ class Chatbot:
 
     def refresh_headers(self) -> None:
         """
-        Refreshes the headers -- Internal use only
+        Refresh the headers -- Internal use only
 
         :return: None
         """
@@ -102,9 +104,10 @@ class Chatbot:
 
     def __get_chat_stream(self, data) -> None:
         """
-        Generator for chat stream -- Internal use only
+        Generator for the chat stream -- Internal use only
 
         :param data: The data to send
+        :type data: :obj:`dict`
 
         :return: None
         """
@@ -140,11 +143,13 @@ class Chatbot:
 
     def __get_chat_text(self, data) -> dict:
         """
-        Gets the chat response as text -- Internal use only
+        Get the chat response as text -- Internal use only
 
         :param data: The data to send
+        :type data: :obj:`dict`
 
         :return: The chat response
+        :rtype: :obj:`dict`
         """
         # Create request session
         s = requests.Session()
@@ -197,7 +202,7 @@ class Chatbot:
 
     def get_chat_response(self, prompt: str, output="text") -> dict or None:
         """
-        Gets the chat response
+        Get the chat response.
 
         :param prompt: The message sent to the chatbot
         :type prompt: :obj:`str`
@@ -205,8 +210,8 @@ class Chatbot:
         :param output: The output type `text` or `stream`
         :type output: :obj:`str`, optional
 
-        :return: The chat response `{"message": "Returned messages", "conversation_id": "conversation ID", "parent_id": "parent ID"}`
-        :rtype: :obj:`dict` or :obj:`None` or :obj:`Exception`
+        :return: The chat response `{"message": "Returned messages", "conversation_id": "conversation ID", "parent_id": "parent ID"}` or None
+        :rtype: :obj:`dict` or :obj:`None`
         """
         data = {
             "action": "next",
@@ -232,18 +237,18 @@ class Chatbot:
 
     def rollback_conversation(self) -> None:
         """
-        Rollbacks the conversation
+        Rollback the conversation.
 
         :return: None
         """
         self.conversation_id = self.conversation_id_prev
         self.parent_id = self.parent_id_prev
 
-    def refresh_session(self) -> Exception or None:
+    def refresh_session(self) -> None:
         """
-        Refreshes the session
+        Refresh the session.
 
-        :return: None or Exception
+        :return: None
         """
         # Either session_token, email and password or Authorization is required
         if self.config.get("session_token"):
@@ -327,7 +332,7 @@ class Chatbot:
 
     def login(self, email: str, password: str) -> None:
         """
-        Logs in to OpenAI
+        Log in to OpenAI.
 
         :param email: The email
         :type email: :obj:`str`

--- a/src/revChatGPT/revChatGPT.py
+++ b/src/revChatGPT/revChatGPT.py
@@ -67,10 +67,22 @@ class Chatbot:
         self.base_url = "https://chat.openai.com/"
         self.request_timeout = request_timeout
         self.captcha_solver = captcha_solver
+        self.headers = {
+            "Host": "chat.openai.com",
+            "Accept": "text/event-stream",
+            "Authorization": "Bearer ",
+            "Content-Type": "application/json",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) "
+            "Version/16.1 Safari/605.1.15",
+            "X-Openai-Assistant-App-Id": "",
+            "Connection": "close",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Referer": "https://chat.openai.com/chat",
+        }
         if ("session_token" in config or ("email" in config and "password" in config)) and refresh:
             self.refresh_session()
         if "Authorization" in config:
-            self.refresh_headers()
+            self.__refresh_headers()
 
     def reset_chat(self) -> None:
         """
@@ -81,7 +93,7 @@ class Chatbot:
         self.conversation_id = None
         self.parent_id = generate_uuid()
 
-    def refresh_headers(self) -> None:
+    def __refresh_headers(self) -> None:
         """
         Refresh the headers -- Internal use only
 
@@ -89,18 +101,7 @@ class Chatbot:
         """
         if not self.config.get("Authorization"):
             self.config["Authorization"] = ""
-        self.headers = {
-            "Host": "chat.openai.com",
-            "Accept": "text/event-stream",
-            "Authorization": "Bearer " + self.config["Authorization"],
-            "Content-Type": "application/json",
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) "
-            "Version/16.1 Safari/605.1.15",
-            "X-Openai-Assistant-App-Id": "",
-            "Connection": "close",
-            "Accept-Language": "en-US,en;q=0.9",
-            "Referer": "https://chat.openai.com/chat",
-        }
+        self.headers["Authorization"] = "Bearer " + self.config["Authorization"]
 
     def __get_chat_stream(self, data) -> None:
         """
@@ -271,10 +272,40 @@ class Chatbot:
                     "like Gecko) Version/16.1 Safari/605.1.15 ",
                 },
             )
-            # Check if response JSON is empty
-            if response.json() == {}:
-                self.debugger.log("Empty response")
-                self.debugger.log("Probably invalid session token")
+            # Check the response code
+            if response.status_code != 200:
+                self.debugger.log(
+                    f"Invalid status code: {response.status_code}")
+                raise Exception("Wrong response code")
+            # Try to get new session token and Authorization
+            try:
+                if 'error' in response.json():
+                    self.debugger.log("Error in response JSON")
+                    self.debugger.log(response.json()['error'])
+                    raise Exception
+                self.config["session_token"] = response.cookies.get(
+                    "__Secure-next-auth.session-token",
+                )
+                self.config["Authorization"] = response.json()["accessToken"]
+                self.__refresh_headers()
+            # If it fails, try to login with email and password to get tokens
+            except Exception:
+                # Check if response JSON is empty
+                if response.json() == {}:
+                    self.debugger.log("Empty response")
+                    self.debugger.log("Probably invalid session token")
+                # Check if ['detail']['code'] == 'token_expired' in response JSON
+                # First check if detail is in response JSON
+                elif 'detail' in response.json():
+                    # Check if code is in response JSON
+                    if 'code' in response.json()['detail']:
+                        # Check if code is token_expired
+                        if response.json()['detail']['code'] == 'token_expired':
+                            self.debugger.log("Token expired")
+                else:
+                    self.debugger.log(f"Response: '{response.text}'")
+                self.debugger.log("Cannot refresh the session, try to login")
+                # Try to login
                 if 'email' in self.config and 'password' in self.config:
                     del self.config['session_token']
                     self.login(self.config['email'],
@@ -283,39 +314,7 @@ class Chatbot:
                     self.debugger.log(
                         "Invalid token and no email and password provided")
                     raise ValueError(
-                        "No email and password provided")
-            # Check if ['detail']['code'] == 'token_expired' in response JSON
-            # First check if detail is in response JSON
-            if 'detail' in response.json():
-                # Check if code is in response JSON
-                if 'code' in response.json()['detail']:
-                    # Check if code is token_expired
-                    if response.json()['detail']['code'] == 'token_expired':
-                        self.debugger.log("Token expired")
-                        if 'email' in self.config and 'password' in self.config:
-                            del self.config['session_token']
-                            self.login(self.config['email'],
-                                       self.config['password'])
-                        else:
-                            self.debugger.log(
-                                "Invalid token and no email and password provided")
-                            raise ValueError(
-                                "No email and password provided")
-            if response.status_code != 200:
-                self.debugger.log(
-                    f"Invalid status code: {response.status_code}")
-                raise Exception("Wrong response code")
-            try:
-                self.config["session_token"] = response.cookies.get(
-                    "__Secure-next-auth.session-token",
-                )
-                self.config["Authorization"] = response.json()["accessToken"]
-                self.refresh_headers()
-            except Exception as exc:
-                print("Error refreshing session")
-                self.debugger.log("Response: '" + str(response.text) + "'")
-                self.debugger.log(str(response.status_code))
-                raise Exception("Error refreshing session") from exc
+                        "Error refreshing session: No email and password provided")
         elif "email" in self.config and "password" in self.config:
             try:
                 self.login(self.config["email"], self.config["password"])
@@ -323,7 +322,7 @@ class Chatbot:
                 self.debugger.log("Login failed")
                 raise exc
         elif "Authorization" in self.config:
-            self.refresh_headers()
+            self.__refresh_headers()
         else:
             self.debugger.log(
                 "No session_token, email and password or Authorization provided")
@@ -368,6 +367,6 @@ class Chatbot:
                         self.config["session_token"] = possible_tokens[0]
                     else:
                         self.config["session_token"] = possible_tokens
-            self.refresh_headers()
+            self.__refresh_headers()
         else:
             raise Exception("Error logging in")

--- a/wiki/asyncChatGPT.md
+++ b/wiki/asyncChatGPT.md
@@ -14,37 +14,38 @@
 def generate_uuid() -> str
 ```
 
-Generates a UUID for the session -- Internal use only
+Generate a UUID for the session -- Internal use only
 
 **Returns**:
 
-str
+`uid` (:obj:`str`): A random UUID
 
 <a id="asyncChatGPT.asyncChatGPT.Chatbot"></a>
 
 ## Chatbot Objects
 
 ```python
-class Chatbot()
+class Chatbot(config, conversation_id=None, parent_id=None, debug=False, refresh=True, request_timeout=100, captcha_solver=None)
 ```
 
-Initializes the chatbot
+Initialize the chatbot.
 
 See wiki for the configuration json:
 https://github.com/acheong08/ChatGPT/wiki/Setup
 
 **Arguments**:
 
-- `config` (`:obj:`json``): The configuration json
-- `conversation_id` (`:obj:`str`, optional`): The conversation ID
-- `parent_id` (`:obj:`str`, optional`): The parent ID
-- `debug` (`:obj:`bool`, optional`): Whether to enable debug mode
-- `refresh` (`:obj:`bool`, optional`): Whether to refresh the session
-- `request_timeout` (`:obj:`int`, optional`): The network request timeout seconds
+- `config` (:obj:`json`): The configuration json
+- `conversation_id` (:obj:`str`, `optional`): The conversation ID
+- `parent_id` (:obj:`str`, `optional`): The parent ID
+- `debug` (:obj:`bool`, `optional`): Whether to enable debug mode
+- `refresh` (:obj:`bool`, `optional`): Whether to refresh the session
+- `request_timeout` (:obj:`int`, `optional`): The network request timeout in seconds
+- `captcha_solver` (:obj:`any`, `optional`): The `CaptchaSolver()` object
 
 **Returns**:
 
-None or Exception
+`Chatbot` (:obj:`Chatbot`): The chatbot object
 
 <a id="asyncChatGPT.asyncChatGPT.Chatbot.reset_chat"></a>
 
@@ -54,7 +55,7 @@ None or Exception
 def reset_chat() -> None
 ```
 
-Resets the conversation ID and parent ID
+Reset the conversation ID and parent ID.
 
 **Returns**:
 
@@ -68,7 +69,7 @@ None
 def refresh_headers() -> None
 ```
 
-Refreshes the headers -- Internal use only
+Refresh the headers -- Internal use only
 
 **Returns**:
 
@@ -79,20 +80,27 @@ None
 #### get\_chat\_response
 
 ```python
-async def get_chat_response(prompt, output="text") -> dict or None
+async def get_chat_response(prompt: str, output="text") -> dict or None
 ```
 
-Gets the chat response
+Get the chat response.
 
 **Arguments**:
 
-- `prompt` (`:obj:`str``): The message sent to the chatbot
-- `output` (`:obj:`str`, optional`): The output type `text` or `stream`
+- `prompt` (:obj:`str`): The message sent to the chatbot
+- `output` (:obj:`str`, `optional`): The type of the output (`"text"` or `"stream"`)
 
 **Returns**:
 
-The chat response `{"message": "Returned messages", "conversation_id": "conversation ID",
-"parent_id": "parent ID"}` :rtype: :obj:`dict` or :obj:`None` or :obj:`Exception`
+The chat response (:obj:`dict`):
+
+```python
+{"message": returned messages (:obj:`str`), 
+ "conversation_id": conversation ID (:obj:`str`),
+ "parent_id": parent ID (:obj:`str`)}
+``` 
+
+or None
 
 <a id="asyncChatGPT.asyncChatGPT.Chatbot.rollback_conversation"></a>
 
@@ -102,7 +110,7 @@ The chat response `{"message": "Returned messages", "conversation_id": "conversa
 def rollback_conversation() -> None
 ```
 
-Rollbacks the conversation
+Rollback the conversation.
 
 **Returns**:
 
@@ -113,14 +121,14 @@ None
 #### refresh\_session
 
 ```python
-def refresh_session() -> Exception or None
+def refresh_session() -> None
 ```
 
-Refreshes the session
+Refresh the session.
 
 **Returns**:
 
-None or Exception
+None
 
 <a id="asyncChatGPT.asyncChatGPT.Chatbot.login"></a>
 
@@ -130,12 +138,12 @@ None or Exception
 def login(email: str, password: str) -> None
 ```
 
-Logs in to OpenAI
+Log in to OpenAI.
 
 **Arguments**:
 
-- `email` (`:obj:`str``): The email
-- `password` (`:obj:`str``): The password
+- `email` (:obj:`str`): The email
+- `password` (:obj:`str`): The password
 
 **Returns**:
 

--- a/wiki/revChatGPT.md
+++ b/wiki/revChatGPT.md
@@ -47,37 +47,38 @@ Solves the captcha
 def generate_uuid() -> str
 ```
 
-Generates a UUID for the session -- Internal use only
+Generate a UUID for the session -- Internal use only
 
 **Returns**:
 
-str
+`uid` (:obj:`str`): A random UUID
 
 <a id="revChatGPT.revChatGPT.Chatbot"></a>
 
 ## Chatbot Objects
 
 ```python
-class Chatbot()
+class Chatbot(config, conversation_id=None, parent_id=None, debug=False, refresh=True, request_timeout=100, captcha_solver=None)
 ```
 
-Initializes the chatbot
+Initialize the chatbot.
 
 See wiki for the configuration json:
 https://github.com/acheong08/ChatGPT/wiki/Setup
 
 **Arguments**:
 
-- `config` (`:obj:`json``): The configuration json
-- `conversation_id` (`:obj:`str`, optional`): The conversation ID
-- `parent_id` (`:obj:`str`, optional`): The parent ID
-- `debug` (`:obj:`bool`, optional`): Whether to enable debug mode
-- `refresh` (`:obj:`bool`, optional`): Whether to refresh the session
-- `request_timeout` (`:obj:`int`, optional`): The network request timeout seconds
+- `config` (:obj:`json`): The configuration json
+- `conversation_id` (:obj:`str`, `optional`): The conversation ID
+- `parent_id` (:obj:`str`, `optional`): The parent ID
+- `debug` (:obj:`bool`, `optional`): Whether to enable debug mode
+- `refresh` (:obj:`bool`, `optional`): Whether to refresh the session
+- `request_timeout` (:obj:`int`, `optional`): The network request timeout in seconds
+- `captcha_solver` (:obj:`any`, `optional`): The `CaptchaSolver()` object
 
 **Returns**:
 
-None or Exception
+`Chatbot` (:obj:`Chatbot`): The chatbot object
 
 <a id="revChatGPT.revChatGPT.Chatbot.reset_chat"></a>
 
@@ -87,7 +88,7 @@ None or Exception
 def reset_chat() -> None
 ```
 
-Resets the conversation ID and parent ID
+Reset the conversation ID and parent ID.
 
 **Returns**:
 
@@ -101,7 +102,7 @@ None
 def refresh_headers() -> None
 ```
 
-Refreshes the headers -- Internal use only
+Refresh the headers -- Internal use only
 
 **Returns**:
 
@@ -115,16 +116,24 @@ None
 def get_chat_response(prompt: str, output="text") -> dict or None
 ```
 
-Gets the chat response
+Get the chat response.
 
 **Arguments**:
 
-- `prompt` (`:obj:`str``): The message sent to the chatbot
-- `output` (`:obj:`str`, optional`): The output type `text` or `stream`
+- `prompt` (:obj:`str`): The message sent to the chatbot
+- `output` (:obj:`str`, `optional`): The type of the output (`"text"` or `"stream"`)
 
 **Returns**:
 
-`:obj:`dict` or :obj:`None` or :obj:`Exception``: The chat response `{"message": "Returned messages", "conversation_id": "conversation ID", "parent_id": "parent ID"}`
+The chat response (:obj:`dict`):
+
+```python
+{"message": returned messages (:obj:`str`), 
+ "conversation_id": conversation ID (:obj:`str`),
+ "parent_id": parent ID (:obj:`str`)}
+``` 
+
+or None
 
 <a id="revChatGPT.revChatGPT.Chatbot.rollback_conversation"></a>
 
@@ -134,7 +143,7 @@ Gets the chat response
 def rollback_conversation() -> None
 ```
 
-Rollbacks the conversation
+Rollback the conversation.
 
 **Returns**:
 
@@ -145,14 +154,14 @@ None
 #### refresh\_session
 
 ```python
-def refresh_session() -> Exception or None
+def refresh_session() -> None
 ```
 
-Refreshes the session
+Refresh the session.
 
 **Returns**:
 
-None or Exception
+None
 
 <a id="revChatGPT.revChatGPT.Chatbot.login"></a>
 
@@ -162,12 +171,12 @@ None or Exception
 def login(email: str, password: str) -> None
 ```
 
-Logs in to OpenAI
+Log in to OpenAI.
 
 **Arguments**:
 
-- `email` (`:obj:`str``): The email
-- `password` (`:obj:`str``): The password
+- `email` (:obj:`str`): The email
+- `password` (:obj:`str`): The password
 
 **Returns**:
 


### PR DESCRIPTION
- Fix some formatting issues in the wiki and make the documentation consistent with the comments in the code
- Refactor
  - make `self.__refresh_headers()` private
  - set `self.headers` when the `Chatbot` is initiated, instead of setting it every time `__refresh_headers()` is called.
  - make logic flows of `refresh_session()` clearer

I raise exception at line ~284 because the response from `api/auth/session` sometimes looks like
```
{"user":{...},
"expires":"...",
"accessToken":"<some token>",
"error":"RefreshAccessTokenError"}
```
to me for expired session tokens.