### PR TITLE
Remove Host from headers and expose base_url as parameters

### DIFF
--- a/src/revChatGPT/revChatGPT.py
+++ b/src/revChatGPT/revChatGPT.py
@@ -112,7 +112,7 @@ class Chatbot:
         :return: None
         """
         response = requests.post(
-            self.base_url+"backend-api/conversation",
+            self.base_url + "backend-api/conversation",
             headers=self.headers,
             data=json.dumps(data),
             stream=True,
@@ -172,7 +172,7 @@ class Chatbot:
                 "https": self.config["proxy"],
             }
         response = s.post(
-            self.base_url+"backend-api/conversation",
+            self.base_url + "backend-api/conversation",
             data=json.dumps(data),
             timeout=self.request_timeout
         )

--- a/src/revChatGPT/revChatGPT.py
+++ b/src/revChatGPT/revChatGPT.py
@@ -58,17 +58,16 @@ class Chatbot:
     request_timeout: int
     captcha_solver: any
 
-    def __init__(self, config, conversation_id=None, parent_id=None, debug=False, refresh=True, request_timeout=100, captcha_solver=None):
+    def __init__(self, config, conversation_id=None, parent_id=None, debug=False, refresh=True, request_timeout=100, captcha_solver=None, base_url="https://chat.openai.com/"):
         self.debugger = Debugger(debug)
         self.debug = debug
         self.config = config
         self.conversation_id = conversation_id
         self.parent_id = parent_id if parent_id else generate_uuid()
-        self.base_url = "https://chat.openai.com/"
+        self.base_url = base_url
         self.request_timeout = request_timeout
         self.captcha_solver = captcha_solver
         self.headers = {
-            "Host": "chat.openai.com",
             "Accept": "text/event-stream",
             "Authorization": "Bearer ",
             "Content-Type": "application/json",


### PR DESCRIPTION
Remove `Host` from `headers` and expose `base_url` as parameters.  

This makes reverse proxy to chat.openai.com possible.  