### PR TITLE
Add termination on Ctrl-C in CLI without a long traceback

### DIFF
--- a/src/revChatGPT/__main__.py
+++ b/src/revChatGPT/__main__.py
@@ -163,6 +163,9 @@ def main():
                     print("Something went wrong!")
                     print(exc)
                     continue
+    except KeyboardInterrupt:
+        print("\nGoodbye!")
+        exit()
     except Exception as exc:
         print("Something went wrong! Please run with --debug to see the error.")
         print(exc)

--- a/src/revChatGPT/__main__.py
+++ b/src/revChatGPT/__main__.py
@@ -2,7 +2,7 @@ import json
 import textwrap
 from os.path import exists
 from os import getenv
-from sys import argv
+from sys import argv, exit
 from svglib.svglib import svg2rlg
 
 from revChatGPT.revChatGPT import Chatbot


### PR DESCRIPTION
Add termination on Ctrl-C in CLI with the message "Goodbye!" instead of a long traceback.