### PR TITLE
Fix httpx LocalProtocolError

### DIFF
--- a/src/revChatGPT/revChatGPT.py
+++ b/src/revChatGPT/revChatGPT.py
@@ -275,7 +275,7 @@ class AsyncChatbot:
                 self.base_url + "api/auth/session",
                 headers={
                     "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, "
-                    "like Gecko) Version/16.1 Safari/605.1.15 ",
+                    "like Gecko) Version/16.1 Safari/605.1.15",
                 },
             )
             # Check the response code


### PR DESCRIPTION
Trailing whitespace raises a httpx.LocalProtocolError https://github.com/encode/httpx/issues/1640 in refresh_session()
`httpx.LocalProtocolError: Illegal header value b'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Safari/605.1.15 '`
Removing the space should fix the issue.