### PR TITLE
Make pytest env var more readable

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,5 +36,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
-      run: |
-        OPENAI_EMAIL="${{ secrets.OPENAI_EMAIL }}" OPENAI_PASSWORD="${{ secrets.OPENAI_PASSWORD }}" pytest
+      run: pytest
+      env:
+        OPENAI_EMAIL: ${{ secrets.OPENAI_EMAIL }}
+        OPENAI_PASSWORD: ${{ secrets.OPENAI_PASSWORD }}


### PR DESCRIPTION
Instead of mapping env vars inline it could be done via `env`

See: https://docs.github.com/en/actions/learn-github-actions/environment-variables

Not sure the tests should depend on Network though :/ feels like it will end up with flaky tests.

Did you consider something like https://vcrpy.readthedocs.io/en/latest/index.html?