### PR TITLE
temporary solution for async in effective way

### DIFF
--- a/src/revChatGPT/revChatGPT.py
+++ b/src/revChatGPT/revChatGPT.py
@@ -25,6 +25,8 @@ def generate_uuid() -> str:
     uid = str(uuid.uuid4())
     return uid
 
+async def __async_func_for_check():
+    pass
 
 class Debugger:
     def __init__(self, debug: bool = False):
@@ -236,7 +238,7 @@ class AsyncChatbot:
         :return: The chat response `{"message": "Returned messages", "conversation_id": "conversation ID", "parent_id": "parent ID"}` or None
         :rtype: :obj:`dict` or :obj:`None`
         """
-        self.refresh_session()
+        self.refresh_session(running_in_async=True)
         data = {
             "action": "next",
             "messages": [
@@ -274,19 +276,17 @@ class AsyncChatbot:
             self.conversation_id = self.conversation_id_prev_queue.pop()
             self.parent_id = self.parent_id_prev_queue.pop()
 
-    def refresh_session(self) -> None:
+    def refresh_session(self, running_in_async = False) -> None:
         """
         Refresh the session.
 
         :return: None
         """
+        if running_in_async:
+            nest_asyncio.apply()
         # Either session_token, email and password or Authorization is required
         if not self.config.get("cf_clearance") or not self.config.get("session_token"):
-            try:
-                asyncio.run(self.get_cf_cookies())
-            except:
-                nest_asyncio.apply()
-                asyncio.run(self.get_cf_cookies())
+            asyncio.run(self.get_cf_cookies())
         if self.config.get("session_token") and self.config.get("cf_clearance"):
             s = httpx.Client()
             if self.config.get("proxy"):
@@ -314,12 +314,8 @@ class AsyncChatbot:
             # Check the response code
             if response.status_code != 200:
                 if response.status_code == 403:
-                    try:
-                        asyncio.run(self.get_cf_cookies())
-                    except:
-                        nest_asyncio.apply()
-                        asyncio.run(self.get_cf_cookies())
-                    self.refresh_session()
+                    asyncio.run(self.get_cf_cookies())
+                    self.refresh_session(running_in_async=running_in_async)
                     return
                 else:
                     self.debugger.log(
@@ -533,15 +529,16 @@ class Chatbot(AsyncChatbot):
         :return: The chat response `{"message": "Returned messages", "conversation_id": "conversation ID", "parent_id": "parent ID"}` or None
         :rtype: :obj:`dict` or :obj:`None`
         """
+        try:
+            asyncio.run(__async_func_for_check()) #Check if running in nest use of asyncio.run() 
+        except RuntimeError:
+            self.debugger.log("detect nest use of asyncio")
+            nest_asyncio.apply()
         self.refresh_session()
         if output == "text":
             coroutine_object = super().get_chat_response(
                 prompt, output, conversation_id, parent_id)
-            try:
-                return asyncio.run(coroutine_object)
-            except RuntimeError:
-                nest_asyncio.apply()
-                return asyncio.run(coroutine_object)
+            return asyncio.run(coroutine_object)
 
         if output == "stream":
             data = {


### PR DESCRIPTION
The issue in #311 happed because the previous code use none-async function `refresh_session()` wich contain `asyncio.run()` into async function `get_chat_response()`, this cause nested use of asyncio.run

Here is temporary solution to fix