### PR TITLE
Fix for the Selenium driver being inaccessable by all branches of the try-catch

### DIFF
--- a/src/revChatGPT/ChatGPT.py
+++ b/src/revChatGPT/ChatGPT.py
@@ -391,18 +391,22 @@ class Chatbot:
 
         :return: None
         """
+
+        print("Spawning browser...")
+
+        options = self.__get_ChromeOptions()
+
+        driver = uc.Chrome(
+            enable_cdp_events=True, options=options,
+            driver_executable_path=self.config.get("driver_exec_path"),
+            browser_executable_path=self.config.get("browser_exec_path")
+        )
+
         try:
             self.cf_cookie_found = False
             self.agent_found = False
             self.cf_clearance = None
             self.user_agent = None
-            options = self.__get_ChromeOptions()
-            print("Spawning browser...")
-            driver = uc.Chrome(
-                enable_cdp_events=True, options=options,
-                driver_executable_path=self.config.get("driver_exec_path"),
-                browser_executable_path=self.config.get("browser_exec_path")
-            )
             print("Browser spawned.")
             driver.add_cdp_listener(
                 "Network.responseReceivedExtraInfo", lambda msg: self.detect_cookies(msg))


### PR DESCRIPTION
In the latest version of the package, the `get_cf_cookies` method has been erroring out with an error showing that the Selenium driver was inaccessible by the `finally` branch of the try-catch statement. _I haven't_ tested this yet, but I moved the `options` & `driver` variables up to the function level. Please let me know if this won't work. I'm not too familiar with the package or source code yet.