### PR TITLE
fix: send valid JSON data in change_title()

### DIFF
--- a/src/revChatGPT/ChatGPT.py
+++ b/src/revChatGPT/ChatGPT.py
@@ -191,7 +191,7 @@ class Chatbot:
 
     def change_title(self, id, title):
         url = BASE_URL + f"backend-api/conversation/{id}"
-        response = self.session.patch(url, data=f'{{"title": {title}}}')
+        response = self.session.patch(url, data=f'{{"title": "{title}"}}')
         self.check_response(response)
 
     def delete_conversation(self, id):


### PR DESCRIPTION
Currently change_title() doesn't work and raise this exception. You forgot to quote the title in JSON data.

> Exception: ('Response code error: ', 422)

