### PR TITLE
change raised exception type to HTTPError when response code != 200

### DIFF
--- a/src/revChatGPT/ChatGPT.py
+++ b/src/revChatGPT/ChatGPT.py
@@ -1,5 +1,6 @@
 import uuid, re, json, tls_client, logging
 import undetected_chromedriver as uc
+from requests.exceptions import HTTPError
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
@@ -129,7 +130,7 @@ class Chatbot:
         if response.status_code != 200:
             print(response.text)
             self.refresh_session()
-            raise Exception("Wrong response code! Refreshing session...")
+            raise HTTPError(f"Wrong response code: {response.status_code}! Refreshing session...")
         else:
             try:
                 response = response.text.splitlines()[-4]


### PR DESCRIPTION
Hey,

Tiny PR which will allow retry libraries to catch a specific exception type when hitting e.g. rate limit and direct their behavior accordingly. On main it was just raising a bare `Exception`.