### PR TITLE
Add customizable user

### DIFF
--- a/src/revChatGPT/Official.py
+++ b/src/revChatGPT/Official.py
@@ -54,7 +54,7 @@ class Chatbot:
         )
 
     def _process_completion(
-        self, user_request: str, completion: dict, conversation_id: str = None
+        self, user_request: str, completion: dict, conversation_id: str = None, user: str = "User"
     ) -> dict:
         if completion.get("choices") is None:
             raise Exception("ChatGPT API returned no choices")
@@ -66,13 +66,13 @@ class Chatbot:
             "<|im_end|>",
         )
         # Add to chat history
-        self.prompt.add_to_history(user_request, completion["choices"][0]["text"])
+        self.prompt.add_to_history(user_request, completion["choices"][0]["text"], user=user)
         if conversation_id is not None:
             self.save_conversation(conversation_id)
         return completion
 
     def _process_completion_stream(
-        self, user_request: str, completion: dict, conversation_id: str = None
+        self, user_request: str, completion: dict, conversation_id: str = None, user: str = "User"
     ) -> str:
         full_response = ""
         for response in completion:
@@ -90,12 +90,12 @@ class Chatbot:
             full_response += response["choices"][0]["text"]
 
         # Add to chat history
-        self.prompt.add_to_history(user_request, full_response)
+        self.prompt.add_to_history(user_request, full_response, user)
         if conversation_id is not None:
             self.save_conversation(conversation_id)
 
     def ask(
-        self, user_request: str, temperature: float = 0.5, conversation_id: str = None
+        self, user_request: str, temperature: float = 0.5, conversation_id: str = None, user: str = "User"
     ) -> dict:
         """
         Send a request to ChatGPT and return the response
@@ -103,23 +103,24 @@ class Chatbot:
         if conversation_id is not None:
             self.load_conversation(conversation_id)
         completion = self._get_completion(
-            self.prompt.construct_prompt(user_request),
+            self.prompt.construct_prompt(user_request, user=user),
             temperature,
         )
-        return self._process_completion(user_request, completion)
+        return self._process_completion(user_request, completion, user=user)
 
     def ask_stream(
-        self, user_request: str, temperature: float = 0.5, conversation_id: str = None
+        self, user_request: str, temperature: float = 0.5, conversation_id: str = None, user: str = "User"
     ) -> str:
         """
         Send a request to ChatGPT and yield the response
         """
         if conversation_id is not None:
             self.load_conversation(conversation_id)
-        prompt = self.prompt.construct_prompt(user_request)
+        prompt = self.prompt.construct_prompt(user_request, user=user)
         return self._process_completion_stream(
             user_request=user_request,
             completion=self._get_completion(prompt, temperature, stream=True),
+            user=user,
         )
 
     def make_conversation(self, conversation_id: str) -> None:
@@ -180,25 +181,26 @@ class AsyncChatbot(Chatbot):
             stream=stream,
         )
 
-    async def ask(self, user_request: str, temperature: float = 0.5) -> dict:
+    async def ask(self, user_request: str, temperature: float = 0.5, user: str = "User") -> dict:
         """
         Same as Chatbot.ask but async
         }
         """
         completion = await self._get_completion(
-            self.prompt.construct_prompt(user_request),
+            self.prompt.construct_prompt(user_request, user=user),
             temperature,
         )
-        return self._process_completion(user_request, completion)
+        return self._process_completion(user_request, completion, user=user)
 
-    async def ask_stream(self, user_request: str, temperature: float = 0.5) -> str:
+    async def ask_stream(self, user_request: str, temperature: float = 0.5, user: str = "User") -> str:
         """
         Same as Chatbot.ask_stream but async
         """
-        prompt = self.prompt.construct_prompt(user_request)
+        prompt = self.prompt.construct_prompt(user_request, user=user)
         return self._process_completion_stream(
             user_request=user_request,
             completion=await self._get_completion(prompt, temperature, stream=True),
+            user=user,
         )
 
 
@@ -229,12 +231,12 @@ class Prompt:
         """
         self.chat_history.append(chat)
     
-    def add_to_history(self, user_request: str, response: str) -> None:
+    def add_to_history(self, user_request: str, response: str, user: str = "User") -> None:
         """
         Add request/response to chat history for next prompt
         """
         self.add_to_chat_history(
-            "User: "
+            user+": "
             + user_request
             + "\n\n\n"
             + "ChatGPT: "
@@ -248,14 +250,14 @@ class Prompt:
         """
         return "\n".join(custom_history or self.chat_history)
 
-    def construct_prompt(self, new_prompt: str, custom_history: list = None) -> str:
+    def construct_prompt(self, new_prompt: str, custom_history: list = None, user: str = "User") -> str:
         """
         Construct prompt based on chat history and request
         """
         prompt = (
             self.base_prompt
             + self.history(custom_history=custom_history)
-            + "User: "
+            + user+": "
             + new_prompt
             + "\nChatGPT:"
         )
@@ -268,7 +270,7 @@ class Prompt:
             # Remove oldest chat
             self.chat_history.pop(0)
             # Construct prompt again
-            prompt = self.construct_prompt(new_prompt)
+            prompt = self.construct_prompt(new_prompt, custom_history, user)
         return prompt
 
 


### PR DESCRIPTION
Allows to pass a custom user name to be provided for the own prompts to all methods of the `ChatBot`. Currently not usable from the command line, I'm not really sure how that would be helpful there...

It is helpful for things like Discord bots though, allowing ChatGPT to differentiate between users and responding in a custom way to each one individually.

Also fixes the recursion of `construct_prompt` not taking the `custom_history` parameter.