### PR TITLE
Change `rstrip` to `removesuffix`

### DIFF
--- a/src/revChatGPT/Official.py
+++ b/src/revChatGPT/Official.py
@@ -67,8 +67,8 @@ class Chatbot:
             raise Exception("ChatGPT API returned no choices")
         if completion["choices"][0].get("text") is None:
             raise Exception("ChatGPT API returned no text")
-        completion["choices"][0]["text"] = completion["choices"][0]["text"].rstrip(
-            "<|im_end|>",
+        completion["choices"][0]["text"] = completion["choices"][0]["text"].removesuffix(
+            "<|im_end|>"
         )
         # Add to chat history
         self.prompt.add_to_history(


### PR DESCRIPTION
rstrip removes the characters from the end of strings until the last character is not present in the set of characters(string) that we send as an argument, as in this case `<|im_end|>`. so after removing this, if our string still has 'i' or 'e' or 'm' etc. at the end. it will also removes that. So, instead we can use `removesuffix` in Python 3.9+. 
In my case i have an 'e' at the end and it is removing every time.  After wasting so much time, i found that. 😂

I found this here: https://stackoverflow.com/questions/46222645/string-rstrip-is-removing-extra-characters