### PR TITLE
修复issues#670问题 

### DIFF
--- a/src/revChatGPT/V2.py
+++ b/src/revChatGPT/V2.py
@@ -146,7 +146,7 @@ class Chatbot:
         body = self.__get_config()
         body["prompt"] = BASE_PROMPT + conversation + "ChatGPT: "
         body["max_tokens"] = get_max_tokens(conversation)
-        async with httpx.AsyncClient().stream(
+        async with httpx.AsyncClient(proxies=self.proxy if self.proxy else None).stream(
             method="POST",
             url=PROXY_URL + "/completions",
             data=json.dumps(body),


### PR DESCRIPTION
#670 
使proxy应用于httpx stream,防止出现当无法访问[https://chat.duti.tech]时,获取access_token成功但ask请求失败的情况(ssl.SSLSyscallError](https://chat.duti.xn--tech%2Caccess_tokenask%28ssl-so19bd13bevg8xkf79bu33c2pjbl9a0y2ceqzett9ej80c3dk.sslsyscallerror/): Some I/O error occurred (_ssl.c:1131))