### PR TITLE
Fix KeyError: 'accessToken'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "httpx[socks]",
         "OpenAIAuth==0.1.1",
         "tiktoken",
+        "requests",
     ],
     extras_require={
         "unofficial": [

--- a/src/revChatGPT/V2.py
+++ b/src/revChatGPT/V2.py
@@ -7,6 +7,7 @@ import os
 import sys
 
 import httpx
+import requests
 import tiktoken
 from OpenAIAuth.OpenAIAuth import OpenAIAuth
 
@@ -196,11 +197,8 @@ class Chatbot:
             auth.begin()
             self.api_key = auth.access_token
         else:
-            response = httpx.post(
-                url=PROXY_URL + "/auth",
-                data={"email": email, "password": password},
-            )
-            self.api_key = response.json()["accessToken"]
+            auth_request = requests.post(PROXY_URL + "/auth", json={"email": email, "password": password})
+            self.api_key = auth_request.json()["accessToken"]
 
 
 def get_input(prompt):


### PR DESCRIPTION
When running with insecure I got the following error:

```
self.api_key = response.json()["accessToken"]
KeyError: 'accessToken'
```

I was able to fix this by using the requests library instead of httpx to send a POST request:
```python
import requests
...
auth_request = requests.post(PROXY_URL + "/auth", json={"email": email, "password": password})
self.api_key = auth_request.json()["accessToken"]
```