### PR TITLE
Change the model ID to new Default Model

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -144,7 +144,7 @@ class Chatbot:
             "parent_message_id": parent_id or str(uuid.uuid4()),
             "model": "text-davinci-002-render-sha"
             if not self.config.get("paid")
-            else "text-davinci-002-render-paid",
+            else "text-davinci-002-render-sha",
         }
         # new_conv = data["conversation_id"] is None
         self.conversation_id_prev_queue.append(


### PR DESCRIPTION
According to the latest ChatGPT website, they already optimized a new model which ID is "text-davinci-002-render-sha".
"text-davinci-002-render-sha" is the original Turbo Model, and becomes the Default Model now.

![image](https://user-images.githubusercontent.com/40751071/218974489-3642e973-a58d-4e36-bb21-ed7d5be19828.png)
The link of this model is `https://chat.openai.com/chat?model=text-davinci-002-render-sha`.