### PR TITLE
Resetting parent_id when switching to a new conversation_id

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -123,6 +123,10 @@ class Chatbot:
             error.code = -1
             raise error
             # user-specified covid and parid, check skipped to avoid rate limit
+
+        if conversation_id is not None and conversation_id != self.conversation_id:  # Update to new conversations
+            self.parent_id = None  # Resetting parent_id
+
         conversation_id = conversation_id or self.conversation_id
         parent_id = parent_id or self.parent_id
         if conversation_id is None and parent_id is None:  # new conversation


### PR DESCRIPTION
We need to reset the `self.parent_id` to `None` when calling `ask` with `conversation_id`, or else the `conversation_id` and `parent_id` will mismatch in the following request, causing the request to fail