### PR TITLE
error handling wrong user and pass

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -62,7 +62,13 @@ class Chatbot:
         else:
             raise Exception("No login details provided!")
         if "access_token" not in config:
-            self.__login()
+            try:
+                self.__login()
+            except Exception:
+                print("Wrong username and password")
+                import sys
+                sys.exit()
+
 
     def __refresh_headers(self, access_token):
         self.session.headers.clear()


### PR DESCRIPTION
My bad for the non-specific error handling, I dived into the OpenAPI.auth to see if there was any logic to handling the wrong username and pass but didn't see anything. By default, it would just return "Wrong status code" since I guess a wrong username and password don't change the status code received. 
<img width="504" alt="image" src="https://user-images.githubusercontent.com/61678138/219513792-436d2250-8786-48f5-9d6b-6d668afaadad.png">
**Before** 
<img width="504" alt="image" src="https://user-images.githubusercontent.com/61678138/219513968-9da500f7-c7a6-437b-b712-b74b6a7995e0.png">
**After** 
<img width="504" alt="image" src="https://user-images.githubusercontent.com/61678138/219514016-fe421ba7-d13c-49a8-ace3-84cf32b2f58b.png">
