### PR TITLE
Fix wrong model name in paid configuration

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -144,6 +144,7 @@ class Chatbot:
             if conversation_id not in self.conversation_mapping:
                 self.__map_conversations()
             parent_id = self.conversation_mapping[conversation_id]
+        is_paid = bool(self.config.get("paid"))
         data = {
             "action": "next",
             "messages": [
@@ -156,7 +157,7 @@ class Chatbot:
             "conversation_id": conversation_id,
             "parent_message_id": parent_id,
             "model": "text-davinci-002-render-sha"
-            if not self.config.get("paid")
+            if is_paid
             else "text-davinci-002-render-paid",
         }
         # new_conv = data["conversation_id"] is None


### PR DESCRIPTION
## Context
- In current code, if config `paid` is truthy, the model becomes 'text-davinci-002-render-paid', and if `paid` is falsy, the model becomes `text-davinci-002-render-sha`.
- But actually the default for paid version is `text-davinci-002-render-sha`, and the legacy model is `text-davinci-002-render-paid` like following pictures.

<img width="1031" alt="Screenshot 2023-02-17 at 16 12 24" src="https://user-images.githubusercontent.com/11153873/219576141-75768626-7749-41e1-8758-a06ba51592f3.png">
<img width="1090" alt="image" src="https://user-images.githubusercontent.com/11153873/219576233-9f1ba79a-c996-487c-b269-7b8df6b0c364.png">

## Changes
### As-Is
- paid -> text-davinci-002-render-paid
- not paid -> text-davinci-002-render-sha
### To-Be
- paid -> text-davinci-002-render-sha
- not paid -> text-davinci-002-render-paid

## Changes