### PR TITLE
Add timeout parameter to ask()

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -110,6 +110,7 @@ class Chatbot:
         prompt,
         conversation_id=None,
         parent_id=None,
+        timeout=360,
         # gen_title=True,
     ):
         """
@@ -164,7 +165,7 @@ class Chatbot:
         response = self.session.post(
             url=BASE_URL + "api/conversation",
             data=json.dumps(data),
-            timeout=360,
+            timeout=timeout,
             stream=True,
         )
         self.__check_response(response)


### PR DESCRIPTION
It seems to me that 360 is too long as a timeout in some situations (for example, for a periodic check of the answer).

Therefore, it makes sense to add timeout as a parameter to the ask function `ask(..., timeout=)`