### PR TITLE
Add exception when "Field missing"

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -188,9 +188,8 @@ class Chatbot:
             except json.decoder.JSONDecodeError:
                 continue
             if not self.__check_fields(line):
-                print("Field missing")
-                print(line)
-                continue
+                raise Exception("Field missing. Details: " + str(line))
+                
             message = line["message"]["content"]["parts"][0]
             conversation_id = line["conversation_id"]
             parent_id = line["message"]["id"]


### PR DESCRIPTION
Now, instead of an exception, it just prints text to the console (for example: `{'detail': 'Too many requests in 1 hour. Try again later.'}`). Therefore, it cannot be caught.

Adding an exception will make it possible to catch this error.