### PR TITLE
Fix garbled text in get_msg_history API response.

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -234,13 +234,15 @@ class Chatbot:
         data = json.loads(response.text)
         return data["items"]
 
-    def get_msg_history(self, convo_id):
+    def get_msg_history(self, convo_id, encoding = None):
         """
         Get message history
         :param id: UUID of conversation
         """
         url = BASE_URL + f"api/conversation/{convo_id}"
         response = self.session.get(url)
+        if encoding != None:
+          response.encoding = encoding
         self.__check_response(response)
         data = json.loads(response.text)
         return data

--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -234,7 +234,7 @@ class Chatbot:
         data = json.loads(response.text)
         return data["items"]
 
-    def get_msg_history(self, convo_id, encoding = None):
+    def get_msg_history(self, convo_id, encoding = "utf-8"):
         """
         Get message history
         :param id: UUID of conversation


### PR DESCRIPTION
Due to character encoding issues causing garbled text in the API response for Chinese characters, an optional parameter has been added to allow specifying the character encoding when calling the API.

**As-Is**
`chatbot.get_msg_history(convo_id)`

'content': {'content_type': 'text', 'parts': ['ä½\xa0ç\x9a\x84å\x90\x8då\xad\x97']},

**To-Be**
`chatbot.get_msg_history(convo_id,"utf-8")`

'content': {'content_type': 'text', 'parts': ['我的名字是ChatGPT。']},