### PR TITLE
fixed the encoding problem in change_title method

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -258,6 +258,7 @@ class Chatbot:
 
     @logger(is_timed=False)
     def __check_response(self, response):
+        response.encoding = response.apparent_encoding
         if response.status_code != 200:
             print(response.text)
             error = Error()
@@ -317,7 +318,7 @@ class Chatbot:
         :param title: String
         """
         url = BASE_URL + f"api/conversation/{convo_id}"
-        response = self.session.patch(url, data=f'{{"title": "{title}"}}')
+        response = self.session.patch(url, data=json.dumps({"title": title}))
         self.__check_response(response)
 
     @logger(is_timed=True)

--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -280,7 +280,7 @@ class Chatbot:
         return data["items"]
 
     @logger(is_timed=True)
-    def get_msg_history(self, convo_id, encoding="utf-8"):
+    def get_msg_history(self, convo_id, encoding=None):
         """
         Get message history
         :param id: UUID of conversation

--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -285,14 +285,13 @@ class Chatbot:
         """
         Get message history
         :param id: UUID of conversation
+        :param encoding: String
         """
         url = BASE_URL + f"api/conversation/{convo_id}"
         response = self.session.get(url)
+        self.__check_response(response)
         if encoding != None:
             response.encoding = encoding
-        else:
-            response.encoding = response.apparent_encoding
-        self.__check_response(response)
         data = json.loads(response.text)
         return data
 

--- a/wiki/V1.md
+++ b/wiki/V1.md
@@ -61,7 +61,7 @@ Get conversations
 #### get\_msg\_history
 
 ```python
-def get_msg_history(convo_id, encoding="utf-8")
+def get_msg_history(convo_id, encoding=None)
 ```
 
 Get message history

--- a/wiki/V1.md
+++ b/wiki/V1.md
@@ -39,7 +39,7 @@ Ask a question to the chatbot
 - `prompt`: String
 - `conversation_id`: UUID
 - `parent_id`: UUID
-- `gen_title`: Boolean
+- `timeout`: Numbers
 
 <a id="revChatGPT.V1.Chatbot.get_conversations"></a>
 


### PR DESCRIPTION
Fix encoding issues in __check_response to detect encoding during runtime. This fix will solve the Chinese garbled characters issue in get_conversations method permanently.

Also, fixed the encoding problem in change_title method, which prevented requests from being made when passing Chinese characters.