### PR TITLE
Avoid unnecessary unescaping for httpx

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -495,10 +495,6 @@ class AsyncChatbot(Chatbot):
                 if "[DONE]" in line:
                     break
 
-                line = (
-                    line.replace('\\"', '"').replace("\\'", "'").replace("\\\\", "\\")
-                )
-
                 try:
                     line = json.loads(line)
                 except json.decoder.JSONDecodeError:


### PR DESCRIPTION
Seems `httpx` could just properly deal with back-slashes, unescaping would break the JSON (the issue was observed at [here](https://github.com/n3d1117/chatgpt-telegram-bot/pull/31)).