### PR TITLE
Support lazy loading of history conversations

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -100,7 +100,7 @@ class Chatbot:
         conversation_id: str | None = None,
         parent_id: str | None = None,
         session_client=None,
-        lazy_loading=False,
+        lazy_loading: bool = False,
     ) -> None:
         user_home = getenv("HOME")
         if user_home is None:


### PR DESCRIPTION
I got so many conversations under my account, everytime the server is restarted, `self.__map_conversations()` is called to create the mapping, which takes quite a long time to finish. This newly introduced options `lazy_loading` can help only load the mapping of single conversation when it's not loaded before.