### PR TITLE
Fix cache dir bug

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -300,7 +300,8 @@ class Chatbot:
                 "access_tokens":{"someone@example.com": 'this account's access token', }
             }
         """
-        os.makedirs(osp.dirname(self.cache_path), exist_ok=True)
+        dirname = osp.dirname(self.cache_path) or "."
+        os.makedirs(dirname, exist_ok=True)
         json.dump(info, open(self.cache_path, "w", encoding="utf-8"), indent=4)
 
     @logger(is_timed=False)


### PR DESCRIPTION
When the `self.cache_path` is in the current working directory (like when the HOME env does not exist on win10), `osp.dirname(self.cache_path)` returns an empty string. Then, the call to `os.makedirs("", exist_ok=True)` crashes. This changes the call to be `os.makedirs(".", exist_ok=True)`, which seems to fix the issue.