### PR TITLE
repair cant create cache_dir when $HOME is None ref:#947

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -131,7 +131,7 @@ class Chatbot:
         """
         user_home = getenv("HOME")
         if user_home is None:
-            self.cache_path = ".chatgpt_cache.json"
+            self.cache_path = osp.join(os.getcwd(),".chatgpt_cache.json")
         else:
             # mkdir ~/.config/revChatGPT
             if not osp.exists(osp.join(user_home, ".config")):


### PR DESCRIPTION
Close: #947 
## Cause
When $HOME is None, the value of cache_path is .chatgpt_cache.json. In this case, `osp.dirname(cache_path)` returns an empty value, and running `os.mkdir(osp.dirname(cache_path))` will result in an error
## Fix
If $HOME is None, set the value of cache_path to the value obtained by using `osp.join(os.getcwd(),".chatgpt_cache.json")`.