### PR TITLE
Raise an error for invalid_token

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -478,6 +478,13 @@ class Chatbot:
                         message=line.get("detail", {}).get("message"),
                         code=3,
                     )
+                if line.get("detail", {}).get("code") == "invalid_token":
+                    log.error("Invalid access token")
+                    raise Error(
+                        source="ask",
+                        message=line.get("detail", {}).get("message"),
+                        code=5,
+                    )
 
                 raise Error(source="ask", message="Field missing", code=1)
             message = line["message"]["content"]["parts"][0]


### PR DESCRIPTION
Problem: Currently getting a false "Field missing" error because the Chatbot.ask method does not handle "invalid_token" response codes from api/conversation.
Solution: This PR adds code to handle "invalid_token" response codes to accurately warn users when they provide an invalid bearer access token instead of just raising "Field missing" (which is also inaccurate because the field is not missing).

Related issue: https://github.com/acheong08/ChatGPT/issues/955