### PR TITLE
Remove LiteralString

### DIFF
--- a/src/revChatGPT/V0.py
+++ b/src/revChatGPT/V0.py
@@ -6,7 +6,6 @@ import json
 import os
 import sys
 from datetime import date
-from typing import LiteralString
 from typing import NoReturn
 
 import openai
@@ -392,7 +391,7 @@ def main() -> NoReturn:
     print("Type '!help' to show a full list of commands")
     print("Press enter twice to submit your question.\n")
 
-    def get_input(prompt) -> LiteralString:
+    def get_input(prompt):
         """
         Multi-line input function
         """


### PR DESCRIPTION
API type 0 stops working with this error:
```
C:\Users\...>C:\Users\...\AppData\Local\Programs\Python\Python310\python -m revChatGPT.V0 -h
Traceback (most recent call last):
  File "C:\Users\...\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\...\AppData\Local\Programs\Python\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\...\AppData\Local\Programs\Python\Python310\lib\site-packages\revChatGPT\V0.py", line 9, in <module>
    from typing import LiteralString
ImportError: cannot import name 'LiteralString' from 'typing' (C:\Users\...\AppData\Local\Programs\Python\Python310\lib\typing.py)
```
Removing return type `LiteralString` fixes it. And I also can't find `LiteralString` at all in the typing package. Perhaps `Literal` was meant?