### PR TITLE
Update openai.api_key and openai.proxy every completion

### DIFF
--- a/src/revChatGPT/V0.py
+++ b/src/revChatGPT/V0.py
@@ -47,8 +47,8 @@ class Chatbot:
         """
         Initialize Chatbot with API key (from https://platform.openai.com/account/api-keys)
         """
-        openai.api_key = api_key or os.environ.get("OPENAI_API_KEY")
-        openai.proxy = proxy or os.environ.get("OPENAI_API_PROXY")
+        self.api_key = api_key
+        self.proxy = proxy
         self.conversations = Conversation()
         self.prompt = Prompt(buffer=buffer)
         self.engine = engine or ENGINE
@@ -62,6 +62,8 @@ class Chatbot:
         """
         Get the completion function
         """
+        openai.api_key = self.api_key
+        openai.proxy = self.proxy
         return openai.Completion.create(
             engine=self.engine,
             prompt=prompt,
@@ -211,6 +213,8 @@ class AsyncChatbot(Chatbot):
         """
         Get the completion function
         """
+        openai.api_key = self.api_key
+        openai.proxy = self.proxy
         return await openai.Completion.acreate(
             engine=self.engine,
             prompt=prompt,

--- a/src/revChatGPT/V0.py
+++ b/src/revChatGPT/V0.py
@@ -47,8 +47,8 @@ class Chatbot:
         """
         Initialize Chatbot with API key (from https://platform.openai.com/account/api-keys)
         """
-        self.api_key = api_key
-        self.proxy = proxy
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        self.proxy = proxy or os.environ.get("OPENAI_API_PROXY")
         self.conversations = Conversation()
         self.prompt = Prompt(buffer=buffer)
         self.engine = engine or ENGINE


### PR DESCRIPTION
If you use V0 and, for example, dalle (calling the `openai` library both there and there), then the `api_key` in V0 may become `None`.

Therefore, it is better to re-assign it each time. The same goes for proxies.

So, instead of initializing them at the `__init__`
```python
openai.api_key = api_key or os.environ.get("OPENAI_API_KEY")
openai.proxy = proxy or os.environ.get("OPENAI_API_PROXY")
```

It's better to save them as class variables
```python
self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
self.proxy = proxy or os.environ.get("OPENAI_API_PROXY")
```

And then, re-assign each time before using `openai.Completion.create` or `openai.Completion.acreate`
```python
openai.api_key = self.api_key
openai.proxy = self.proxy
```