### PR TITLE
[refactor] using typing modules.

### DIFF
--- a/src/revChatGPT/utils.py
+++ b/src/revChatGPT/utils.py
@@ -71,7 +71,7 @@ async def get_input_async(
     )
 
 
-def get_filtered_keys_from_object(obj: object, *keys: str) -> set[str]:
+def get_filtered_keys_from_object(obj: object, *keys: str) -> Set[str]:
     """
     Get filtered list of object variable names.
     :param keys: List of keys to include. If the first key is "not", the remaining keys will be removed from the class keys.


### PR DESCRIPTION
## Cause

`set[str]` is not supported in old python version(before 3.10):

```python
    def get_filtered_keys_from_object(obj: object, *keys: str) -> set[str]:
TypeError: 'type' object is not subscriptable
```

so it's recommended to use `typing` module  annotate types instead the class `set`