### PR TITLE
fix: Unsupported engine error not displayed correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if not PATH.exists():
 
 setup(
     name="revChatGPT",
-    version="4.2.3",
+    version="4.2.4",
     description="ChatGPT is a reverse engineering of OpenAI's ChatGPT API",
     long_description=open(PATH, encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -71,7 +71,7 @@ def logger(is_timed: bool):
     return decorator
 
 
-BASE_URL = environ.get("CHATGPT_BASE_URL") or "https://chat.gateway.do/api/"
+BASE_URL = environ.get("CHATGPT_BASE_URL") or "https://ai.fakeopen.com/api/"
 
 bcolors = t.Colors()
 

--- a/src/revChatGPT/V3.py
+++ b/src/revChatGPT/V3.py
@@ -135,7 +135,7 @@ class Chatbot:
             "gpt-4-32k",
             "gpt-4-32k-0314",
         ]:
-            raise NotImplementedError("Unsupported engine {self.engine}")
+            raise NotImplementedError(f"Unsupported engine {self.engine}")
 
         tiktoken.model.MODEL_TO_ENCODING["gpt-4"] = "cl100k_base"
 


### PR DESCRIPTION
During my use, I selected the `TEXT-DAVINCI-003` model, 
But it always returns `Unsupported engine {self.engine}`, I think he should return Unsupported engine TEXT-DAVINCI-003 is correct.
I think this should be a bug.