### PR TITLE
Refactor

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -1352,7 +1352,7 @@ Current date: {datetime.datetime.now().strftime("%Y-%m-%d")}
                 times += 1
                 if times >= 5:
                     continue
-                api = plugins.get(result["recipient"], None)
+                api = plugins.get(result["recipient"])
                 if not api:
                     msg = {
                         "id": str(uuid.uuid4()),

--- a/src/revChatGPT/recipient.py
+++ b/src/revChatGPT/recipient.py
@@ -35,11 +35,10 @@ class RecipientMeta(ABCMeta):
     Metaclass for the Recipient class.
     """
 
-    def __new__(mcs, name, bases, namespace, /, **kwargs):
-        if not "RECIPIENT_NAME" in namespace or not namespace["RECIPIENT_NAME"]:
+    def __new__(cls, name, bases, namespace, /, **kwargs):
+        if "RECIPIENT_NAME" not in namespace or not namespace["RECIPIENT_NAME"]:
             namespace["RECIPIENT_NAME"] = name
-        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
-        return cls
+        return super().__new__(cls, name, bases, namespace, **kwargs)
 
 
 class Recipient(metaclass=RecipientMeta):

--- a/tests/test_recipient.py
+++ b/tests/test_recipient.py
@@ -6,7 +6,7 @@ from revChatGPT.recipient import PythonRecipient
 from revChatGPT.V1 import Chatbot
 
 
-def test_recipient():
+def test_recipient() -> None:
     """
     Test the chatbot
     """
@@ -18,7 +18,7 @@ def test_recipient():
     # Try to get the recipient which is not registered
     try:
         _ = cbt.recipients["python"]
-        assert False
+        raise AssertionError
     except Exception as ex:
         assert isinstance(ex, KeyError)
         assert ex.args[0] == "Recipient 'python' is not registered."
@@ -30,7 +30,7 @@ def test_recipient():
     # Try to register the recipient which is already registered
     try:
         cbt.recipients["python"] = PythonRecipient
-        assert False
+        raise AssertionError
     except Exception as ex:
         assert isinstance(ex, KeyError)
         assert ex.args[0] == "Recipient 'python' is already registered."
@@ -48,7 +48,7 @@ def test_recipient():
 
     {python.API_DOCS}
     """
-    for _ in cbt.ask("You are ChatGPT." + api_docs):
+    for _ in cbt.ask(f"You are ChatGPT.{api_docs}"):
         pass
 
     # Test the python recipient


### PR DESCRIPTION
- Apply De-Morgan identities to `src\revChatGPT\recipient.py`
- Return immediate inline variable in `src\revChatGPT\recipient.py`
- Remove `None` from default `get` in `src\revChatGPT\V1.py`
- Apply f-strings and `raise AssertionError` instead of `assert False` in `tests\test_recipient.py`