### PR TITLE
Experimental pure Python Cloudflare bypass

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -3,8 +3,6 @@ Standard ChatGPT
 """
 from __future__ import annotations
 
-import sys
-import asyncio
 import base64
 import binascii
 import contextlib

--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -1338,7 +1338,6 @@ def main(config: dict) -> NoReturn:
                 print("Please include plugin name in command")
         elif command == "!exit":
             chatbot.session.close()
-            chatbot.clear_conversation_stream()
             exit()
         else:
             return False

--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -82,7 +82,7 @@ def logger(is_timed: bool):
     return decorator
 
 
-BASE_URL = environ.get("CHATGPT_BASE_URL") or "https://chat.openai.com/backend-api/" # "https://bypass.churchless.tech/"
+BASE_URL = environ.get("CHATGPT_BASE_URL") or "https://bypass.churchless.tech/" # "https://chat.openai.com/backend-api/"
 
 bcolors = t.Colors()
 


### PR DESCRIPTION
Been playing around with this to avoid using the GO proxy method for TLS spoofing. It uses `curl-cffi` module to spoof the TLS fingerprint (I set chrome110). But, since that module doesn't support stream=True on requests, a workaround is to write `content_callback` to a temp file, then read from it, then delete. For async it is the same principle, just uses AsyncSession instead. 
Works well enough from my various tests, but can never be 100% sure. For example, the following outputs every task result correctly with no parts missing or any weirdness like that.


```py
import asyncio
import sys
from revChatGPT.V1 import Chatbot, AsyncChatbot
from const import access_token, conversation_id
    
# Needed on my Windows machine for asyncio, idk why
if sys.version_info >= (3, 8) and sys.platform.lower().startswith("win"):
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

async def run_prompt(prompt: str, idx: int):
    bot = AsyncChatbot(config={'access_token': access_token}, conversation_id=conversation_id)
    print(f'Task {idx}:\n') 
    prev_text = ""
    async for data in bot.ask(prompt):
        message = data["message"][len(prev_text):]
        print(message, end="", flush=True)
        prev_text = data["message"]
    print('\n'*2)

def start_tasks(tasks: list):
    for i, task in enumerate(tasks):
        asyncio.run(run_prompt(task, i+1))
    
tasks = ['Calculate the sum of the first 10 prime numbers', 'Tell me what distance is the moon from earth', 'Write "Hello World" in C']    

def main():
    print('\nAsync Taskbot:\n')
    start_tasks(tasks)

if __name__ == '__main__':
    main()
```

So this change allows to use the official `https://chat.openai.com/backend-api/conversation` endpoint without having to spin up a local proxy or using a bypass site, but only on those IPs where the CF challenge isn't triggered for whatever reason.  