### PR TITLE
[6.3.2] Support for all 0613 models

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if not PATH.exists():
 
 setup(
     name="revChatGPT",
-    version="6.3.1",
+    version="6.3.2",
     description="ChatGPT is a reverse engineering of OpenAI's ChatGPT API",
     long_description=open(PATH, encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/src/revChatGPT/V3.py
+++ b/src/revChatGPT/V3.py
@@ -27,11 +27,13 @@ ENGINES = [
     "gpt-3.5-turbo-16k",
     "gpt-3.5-turbo-0301",
     "gpt-3.5-turbo-0613",
+    "gpt-3.5-turbo-16k-0613",
     "gpt-4",
     "gpt-4-0314",
     "gpt-4-32k",
     "gpt-4-32k-0314",
     "gpt-4-0613",
+    "gpt-4-32k-0613",
 ]
 
 


### PR DESCRIPTION
I believe you missed two of the newly added models released by OpenAI on 06/13:
 "gpt-3.5-turbo-16k-0613"
 "gpt-4-32k-0613"
 
 
![image](https://github.com/acheong08/ChatGPT/assets/1166162/b7e674c8-bc64-4ded-ae59-6de8c49a327a)

![image](https://github.com/acheong08/ChatGPT/assets/1166162/b91af959-ae01-4e14-a6d0-358e9be76457)
