### PR TITLE
[Bug] Error has not been raised correctly in V3 if server facing issues while processing api

### DIFF
--- a/src/revChatGPT/V3.py
+++ b/src/revChatGPT/V3.py
@@ -308,6 +308,8 @@ class Chatbot:
                 if line == "[DONE]":
                     break
                 resp: dict = json.loads(line)
+                if 'error' in resp:
+                    raise t.ResponseError(f"{resp['error']}")
                 choices = resp.get("choices")
                 if not choices:
                     continue


### PR DESCRIPTION
I am facing the following error while call the V3 ask API with model `gpt-4-0613`. 
(Note: the status_code is 200)
![image](https://github.com/acheong08/ChatGPT/assets/5254737/e9613af7-7e95-4e77-867d-d990f417ea77)


The `ask_stream_async` will not raise any errors correctly, instead it will continue to add an entry `{"role": "", "content": ""}`  to the conversation history, which will block **all** conversation after that error API call:
![image](https://github.com/acheong08/ChatGPT/assets/5254737/3836f091-2975-439a-b913-278c587f7ca6)
![image](https://github.com/acheong08/ChatGPT/assets/5254737/4bcd1b98-92ef-4443-ae5d-3ff58dc3e27e)
 
