### PR TITLE
update the V1 get access token  because OpenAIAuth update to 2.0.0

### DIFF
--- a/src/revChatGPT/V1.py
+++ b/src/revChatGPT/V1.py
@@ -372,7 +372,7 @@ class Chatbot:
         )
         log.debug("Using authenticator to get access token")
 
-        self.set_access_token(auth.auth())
+        self.set_access_token(auth.get_access_token())
 
     @logger(is_timed=True)
     def __send_request(


### PR DESCRIPTION
the auth method was renamed to get_access_token in version 2.0 of OpenAIAuth