### PR TITLE
Support set max_tokens in the V3 ask api

### DIFF
--- a/src/revChatGPT/V3.py
+++ b/src/revChatGPT/V3.py
@@ -231,7 +231,8 @@ class Chatbot:
                 ),
                 "n": kwargs.get("n", self.reply_count),
                 "user": role,
-                "max_tokens": self.get_max_tokens(convo_id=convo_id),
+                "max_tokens": min(self.get_max_tokens(convo_id=convo_id)
+                                  , kwargs.get("max_tokens", self.max_tokens)),
             },
             timeout=kwargs.get("timeout", self.timeout),
             stream=True,
@@ -303,7 +304,8 @@ class Chatbot:
                 ),
                 "n": kwargs.get("n", self.reply_count),
                 "user": role,
-                "max_tokens": self.get_max_tokens(convo_id=convo_id),
+                "max_tokens": min(self.get_max_tokens(convo_id=convo_id)
+                                  , kwargs.get("max_tokens", self.max_tokens)),
             },
             timeout=kwargs.get("timeout", self.timeout),
         ) as response:


### PR DESCRIPTION
I want to limit the response of openai api. Currently in revChatGPT, the max_tokens was calculated automatically.

Commit messages generated by chatgpt:
feat(V3.py): add support for max_tokens parameter in Chatbot class to limit the number of tokens in a response
refactor(V3.py): use min function to choose the smaller value between the current max_tokens and the new max_tokens parameter to ensure the response does not exceed the desired length



